### PR TITLE
Updating `v1` branch marker with changes from `v1.1.0`.

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/setup-ghdl.iml" filepath="$PROJECT_DIR$/.idea/setup-ghdl.iml" />
+    </modules>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# `setup-ghdl` GitHub Action


### PR DESCRIPTION
# New Features

* Use `inventory.json` to read asset filenames contained in a release.
* Unified all installation methods to use a single shell (Bash).
  * macOS uses Bash 5.2 installed via Homebrew.
  * Windows (native) uses Git Bash and installs `jq` via curl.
  * MSYS2 installations install `jq` via pacman.
* Improved error reporting based on `inventory.json`.  
  * All errors are also reported to the pipeline summary page.

# Changes

* Disabled support for version `latest`.  
  This feature needs a new entry in `inventory.json` to point to the latest none-nightly release.
* Added collapsible sections for multi-line outputs (downloads via curl, unzip, ...)

# Bug Fixes

*None*

# Documentation

* Improved README.

# Unit Tests

* Added more (failing) testcases to check error reporting.

----------
# Related Issues and Pull-Requests

* ghdl/ghdl#2857
