### PR TITLE
Get latest version from nightly

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -106,7 +106,7 @@ jobs:
           update: true
 
       - name: Setup GHDL (${{ matrix.os.backend }}) ${{ matrix.version.install }} on ${{ matrix.os.runtime }}
-        uses: ghdl/setup-ghdl@dev
+        uses: ghdl/setup-ghdl@paebbels/get-latest-version-from-nightly
         with:
           version: ${{ matrix.version.install }}
           backend: ${{ matrix.os.backend }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -42,13 +42,13 @@ jobs:
           - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm'    }
 ###       - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'mcode'   }  # mcode not supported on aarch64
           - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm'    }
-          - {icon: '🪟',   name: 'Windows', image: 'windows-2022', runtime: '',        backend: 'mcode'   }
-          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'   }
-          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'    }
-          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}
-          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'   }
-          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'    }
-          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}
+          - {icon: '🪟',   name: 'Windows', image: 'windows-2025', runtime: '',        backend: 'mcode'   }
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'mcode'   }
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'    }
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm-jit'}
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'mcode'   }
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm'    }
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm-jit'}
         version:
           - {install: '5.0.1',   expected: '5.0.1'}
           - {install: '5.1.1',   expected: '5.1.1'}
@@ -63,20 +63,20 @@ jobs:
           - {os: {runtime: "ucrt64",  backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility (v5.0.1 used LLVM-19, MSYS2 uses LLVM-20+) -> purged from release
         include:
           # old version with retrofitted inventory.json
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'},    option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'},    option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'mcode'},    option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'mcode'},    option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: false}}
           # because of LLVM incompatibility
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
           # error message testing (outdated os version, wrong backend, unsupported backend, unsupported runtime, ...)
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'mcode'},    option: {can-fail: true }}
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'},    option: {can-fail: true }}
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  },    option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🪟⬛', name: 'Windows', image: 'windows-2025', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
 
     continue-on-error: ${{ matrix.option.can-fail }}
 
@@ -96,7 +96,7 @@ jobs:
 #          fi
 
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🟦 Setup MSYS2 for ${{ matrix.os.runtime }}
         uses: msys2/setup-msys2@v2

--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,20 @@ runs:
 
         # A generic test for supported named versions or tagged versions.
         if [[ "${{ inputs.version }}" == "latest" ]]; then
+          DOWNLOAD_URL="https://github.com/ghdl/ghdl/releases/download/nightly/inventory.json"
+          printf "::group::${ANSI_LIGHT_BLUE}%s${ANSI_NOCOLOR}\n" "Downloading nightly inventory file from '${DOWNLOAD_URL}' ..."
+          curl -L --fail "${DOWNLOAD_URL}" -o nightly.json
+          retCode=$?
+          printf "::endgroup::\n  Downloading nightly inventory "
+          if [[ $retCode -eq 0 ]]; then
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          else
+            printf "${ANSI_LIGHT_RED}%s\${ANSI_NOCOLOR}n" "[FAILED]"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Failed to download 'inventory.json' as 'nightly.json'."
+            exit 1
+          fi
+
+
           # TODO: could be read from nightly's inventory.json
           VERSION_IN_URL="v5.1.1"
         elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?|nightly$ ]]; then

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
           fi
 
           osName="Windows"
-          osMajorVersion="2022"
+          osMajorVersion="2025"
           osArchitecture="x86-64"
         else
           printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported runner OS '${{ runner.os }}'."

--- a/action.yml
+++ b/action.yml
@@ -150,7 +150,9 @@ runs:
         fi
 
         # A generic test for supported named versions or tagged versions.
-        if [[ "${{ inputs.version }}" == "latest" ]]; then
+        if [[ "${{ inputs.version }}" == "nightly" ]]; then
+          VERSION_IN_URL="nightly"
+        elif [[ "${{ inputs.version }}" == "latest" ]]; then
           DOWNLOAD_URL="https://github.com/ghdl/ghdl/releases/download/nightly/inventory.json"
           printf "::group::${ANSI_LIGHT_BLUE}%s${ANSI_NOCOLOR}\n" "Downloading nightly inventory file from '${DOWNLOAD_URL}' ..."
           curl -L --fail "${DOWNLOAD_URL}" -o nightly.json
@@ -164,10 +166,21 @@ runs:
             exit 1
           fi
 
+          printf "%s" "Check if 'latest release' is supported (JSON structure version 1.1) ... "
+          if jq -e ".version != \"1.1\"" nightly.json > /dev/null; then
+            printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[OUTDATED]"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported feature 'install latest version' due to outdated 'inventory.json' format."
+            exit 1
+          elif jq -e ".meta | has(\"latest\")" nightly.json > /dev/null; then
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          else
+            printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[UNSUPPORTED]"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported feature 'install latest version' due to missing information in 'inventory.json' downloaded from latest 'nightly' release."
+            exit 1
+          fi
 
-          # TODO: could be read from nightly's inventory.json
-          VERSION_IN_URL="v5.1.1"
-        elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?|nightly$ ]]; then
+          VERSION_IN_URL="$(jq -r '.meta.latest.version' nightly.json)"
+        elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?$ ]]; then
           VERSION_IN_URL="${{ inputs.version }}"
         elif [[ "${{ inputs.version }}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?$ ]]; then
           VERSION_IN_URL="v${{ inputs.version }}"

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ runs:
           fi
 
           printf "%s" "Check if 'latest release' is supported (JSON structure version 1.1) ... "
-          if jq -e ".version != \"1.1\"" nightly.json > /dev/null; then
+          if jq -e ".version | tonumber | . < 1.1" nightly.json > /dev/null; then
             printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[OUTDATED]"
             printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported feature 'install latest version' due to outdated 'inventory.json' format."
             exit 1
@@ -209,6 +209,15 @@ runs:
         else
           printf "${ANSI_LIGHT_RED}%s\${ANSI_NOCOLOR}n" "[FAILED]"
           printf "::error title=%s::%s\n" "setup-ghdl" "Failed to download 'inventory.json'."
+          exit 1
+        fi
+
+        printf "%s" "Check JSON structure version ... "
+        if jq -e ".version | tonumber | . >= 1.0 and . < 2.0" inventory.json > /dev/null; then
+          printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+        else
+          printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[MISMATCH]"
+          printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported version '$(jq ".version" inventory.json)' of 'inventory.json' format."
           exit 1
         fi
 


### PR DESCRIPTION
# New Features

* Updated Windows Server image to 2025.
* Added a new symbolic version `latest`:
  * Download `inventory.json` from latest GHDL `nightly` release.
  * Check if `inventory.json` has a supported data structure version for this feature (currently `1.1`).
  * Readout version of the latest release (currently `v5.1.1`).
* Check if `inventory.json` has a supported data structure version (currently `1.0` and `1.1`).

# Unit Tests

* Bumped dependencies.
* Updated Windows Server image to 2025.
