### PR TITLE
Updating v1 from main@1.3.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global repository setting
+* @tgingold
+
+# GitHub Action pipeline and pipeline templates
+/.github/workflows/ @Paebbels

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,5 @@ updates:
       - Dependencies
     assignees:
       - Paebbels
-    reviewers:
-      - Paebbels
     schedule:
       interval: "daily"    # Checks on Monday trough Friday.

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -80,15 +80,18 @@ jobs:
         shell: bash
 
     steps:
-      - name: Detect correct shell
-        id: detect
-        run: |
-          # Detect correct shell
-          if [[ "${{ matrix.os.name }}" == "Windows" && "${{ matrix.os.runtime }}" != "" ]]; then
-            printf "shell=msys2 {0}" >> $GITHUB_OUTPUT
-          else
-            printf "shell=bash" >> $GITHUB_OUTPUT
-          fi
+#      - name: Detect correct shell
+#        id: detect
+#        run: |
+#          # Detect correct shell
+#          if [[ "${{ matrix.os.name }}" == "Windows" && "${{ matrix.os.runtime }}" != "" ]]; then
+#            printf "shell=msys2 {0}" >> $GITHUB_OUTPUT
+#          else
+#            printf "shell=bash" >> $GITHUB_OUTPUT
+#          fi
+
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v4
 
       - name: 🟦 Setup MSYS2 for ${{ matrix.os.runtime }}
         uses: msys2/setup-msys2@v2
@@ -105,10 +108,9 @@ jobs:
           runtime: ${{ matrix.os.runtime }}
           investigate: true
 
-      - name: Verify on Linux, macOS and Windows (native)
+      - name: Verify GHDL version on Linux, macOS and Windows (native)
         if: matrix.os.name == 'Ubuntu' || matrix.os.name == 'macOS' || ( matrix.os.name == 'Windows' && matrix.os.runtime == '' )
         run: |
-
           ANSI_LIGHT_RED=$'\x1b[91m'
           ANSI_LIGHT_GREEN=$'\x1b[92m'
           ANSI_NOCOLOR=$'\x1b[0m'
@@ -126,7 +128,7 @@ jobs:
             ghdl --version
           fi
 
-      - name: Verify on Windows + MSYS2
+      - name: Verify GHDL version on Windows + MSYS2
         if: matrix.os.name == 'Windows' && matrix.os.runtime != ''
         shell: "msys2 {0}"
         run: |
@@ -147,9 +149,32 @@ jobs:
             ghdl --version
           fi
 
-      - name: Verify on Windows (native) with Powershell
+      - name: Verify GHDL version on Windows (native) with Powershell
         if: matrix.os.name == 'Windows' && matrix.os.runtime == ''
         shell: powershell
         run: |
           echo $(Get-Command ghdl).Source
           ghdl --version
+
+      - name: Check HelloWorld example on Linux, macOS and Windows (native)
+        if: matrix.os.name == 'Ubuntu' || matrix.os.name == 'macOS' || ( matrix.os.name == 'Windows' && matrix.os.runtime == '' )
+        run: |
+          ghdl -a --std=08 example/HelloWorld.vhdl
+          ghdl -e --std=08 HelloWorld
+          ghdl -r --std=08 HelloWorld
+
+      - name: Check HelloWorld example on Windows + MSYS2
+        if: matrix.os.name == 'Windows' && matrix.os.runtime != ''
+        shell: "msys2 {0}"
+        run: |
+          ghdl -a --std=08 example/HelloWorld.vhdl
+          ghdl -e --std=08 HelloWorld
+          ghdl -r --std=08 HelloWorld
+
+      - name: Check HelloWorld example on Windows (native) with Powershell
+        if: matrix.os.name == 'Windows' && matrix.os.runtime == ''
+        shell: powershell
+        run: |
+          ghdl -a --std=08 example/HelloWorld.vhdl
+          ghdl -e --std=08 HelloWorld
+          ghdl -r --std=08 HelloWorld

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -67,7 +67,7 @@ jobs:
           - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
           - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
           - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
-
+          # error message testing (outdated os version, wrong backend, unsupported runtime, ...)
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-20.04', runtime: '',        backend: 'mcode'},    option: {can-fail: true }}
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'},    option: {can-fail: true }}
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  },    option: {can-fail: true }}
@@ -100,7 +100,7 @@ jobs:
           msystem: ${{ matrix.os.runtime }}
           update: true
 
-      - name: Setup GHDL ${{ matrix.os.backend }}
+      - name: Setup GHDL (${{ matrix.os.backend }}) ${{ matrix.version.install }} on ${{ matrix.os.runtime }}
         uses: ghdl/setup-ghdl@dev
         with:
           version: ${{ matrix.version.install }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -48,15 +48,30 @@ jobs:
           - {install: 'nightly', expected: '6.0.0-dev'}
         option:
           - {can-fail: false}
+        exclude:
+          - {os: {runtime: "mingw64", backend: "llvm"},     version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
+          - {os: {runtime: "mingw64", backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
+          - {os: {runtime: "ucrt64",  backend: "llvm"},     version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
+          - {os: {runtime: "ucrt64",  backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
         include:
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'}, option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},  option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'}, option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},  option: {can-fail: false}}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-20.04', runtime: '',        backend: 'mcode'}, option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'}, option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  }, option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'}, option: {can-fail: true }}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'},    option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'},    option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: false}}
+          # because of LLVM incompatibility
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
+
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-20.04', runtime: '',        backend: 'mcode'},    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'},    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  },    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
 
     continue-on-error: ${{ matrix.option.can-fail }}
 

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -106,7 +106,7 @@ jobs:
           update: true
 
       - name: Setup GHDL (${{ matrix.os.backend }}) ${{ matrix.version.install }} on ${{ matrix.os.runtime }}
-        uses: ghdl/setup-ghdl@dev
+        uses: ghdl/setup-ghdl@paebbels/get-latest-version-from-nightly
         with:
           version: ${{ matrix.version.install }}
           backend: ${{ matrix.os.backend }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -106,7 +106,7 @@ jobs:
           update: true
 
       - name: Setup GHDL (${{ matrix.os.backend }}) ${{ matrix.version.install }} on ${{ matrix.os.runtime }}
-        uses: ghdl/setup-ghdl@paebbels/get-latest-version-from-nightly
+        uses: ghdl/setup-ghdl@dev
         with:
           version: ${{ matrix.version.install }}
           backend: ${{ matrix.os.backend }}

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -42,13 +42,13 @@ jobs:
           - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm'    }
 ###       - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'mcode'   }  # mcode not supported on aarch64
           - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm'    }
-          - {icon: '🪟',   name: 'Windows', image: 'windows-2022', runtime: '',        backend: 'mcode'   }
-          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'   }
-          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'    }
-          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}
-          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'   }
-          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'    }
-          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}
+          - {icon: '🪟',   name: 'Windows', image: 'windows-2025', runtime: '',        backend: 'mcode'   }
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'mcode'   }
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'    }
+          - {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm-jit'}
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'mcode'   }
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm'    }
+          - {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm-jit'}
         version:
           - {install: '5.0.1',   expected: '5.0.1'}
           - {install: '5.1.1',   expected: '5.1.1'}
@@ -63,20 +63,20 @@ jobs:
           - {os: {runtime: "ucrt64",  backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility (v5.0.1 used LLVM-19, MSYS2 uses LLVM-20+) -> purged from release
         include:
           # old version with retrofitted inventory.json
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'},    option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'},    option: {can-fail: false}}
-          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'mcode'},    option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'mcode'},    option: {can-fail: false}}
+          - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: false}}
           # because of LLVM incompatibility
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2025', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2025', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
           # error message testing (outdated os version, wrong backend, unsupported backend, unsupported runtime, ...)
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'mcode'},    option: {can-fail: true }}
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'},    option: {can-fail: true }}
           - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  },    option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🪟⬛', name: 'Windows', image: 'windows-2025', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
 
     continue-on-error: ${{ matrix.option.can-fail }}
 
@@ -96,7 +96,7 @@ jobs:
 #          fi
 
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🟦 Setup MSYS2 for ${{ matrix.os.runtime }}
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright © 2024 The GHDL Developers
+# Copyright © 2025 The GHDL Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
@@ -28,13 +28,20 @@ jobs:
       fail-fast: false
       matrix:
         os:
+###       - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'mcode'   }  # GHDL doesn't provide assets for Ubuntu-22.04
+###       - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'llvm'    }  # GHDL doesn't provide assets for Ubuntu-22.04
+###       - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'llvm-jit'}  # GHDL doesn't provide assets for Ubuntu-22.04
+###       - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'gcc'     }  # GHDL doesn't provide assets for Ubuntu-22.04
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'mcode'   }
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'llvm'    }
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'llvm-jit'}
           - {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'gcc'     }
           - {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'mcode'   }
           - {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'llvm'    }
+###       - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'mcode'   }  # mcode not supported on aarch64
           - {icon: '🍏',   name: 'macOS',   image: 'macos-14',     runtime: '',        backend: 'llvm'    }
+###       - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'mcode'   }  # mcode not supported on aarch64
+          - {icon: '🍏',   name: 'macOS',   image: 'macos-15',     runtime: '',        backend: 'llvm'    }
           - {icon: '🪟',   name: 'Windows', image: 'windows-2022', runtime: '',        backend: 'mcode'   }
           - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'   }
           - {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'    }
@@ -44,34 +51,32 @@ jobs:
           - {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}
         version:
           - {install: '5.0.1',   expected: '5.0.1'}
-          - {install: 'latest',  expected: '5.0.1'}
+          - {install: '5.1.1',   expected: '5.1.1'}
+          - {install: 'latest',  expected: '5.1.1'}
           - {install: 'nightly', expected: '6.0.0-dev'}
         option:
           - {can-fail: false}
         exclude:
-          - {os: {runtime: "mingw64", backend: "llvm"},     version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
-          - {os: {runtime: "mingw64", backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
-          - {os: {runtime: "ucrt64",  backend: "llvm"},     version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
-          - {os: {runtime: "ucrt64",  backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility -> purged from release
+          - {os: {runtime: "mingw64", backend: "llvm"},     version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility (v5.0.1 used LLVM-19, MSYS2 uses LLVM-20+) -> purged from release
+          - {os: {runtime: "mingw64", backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility (v5.0.1 used LLVM-19, MSYS2 uses LLVM-20+) -> purged from release
+          - {os: {runtime: "ucrt64",  backend: "llvm"},     version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility (v5.0.1 used LLVM-19, MSYS2 uses LLVM-20+) -> purged from release
+          - {os: {runtime: "ucrt64",  backend: "llvm-jit"}, version: {expected: "5.0.1"}}  # excluded due to LLVM incompatibility (v5.0.1 used LLVM-19, MSYS2 uses LLVM-20+) -> purged from release
         include:
+          # old version with retrofitted inventory.json
           - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'mcode'},    option: {can-fail: false}}
           - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: false}}
           - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'mcode'},    option: {can-fail: false}}
           - {version: {install: '4.1.0',   expected: '4.1.0'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: false}}
           # because of LLVM incompatibility
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
-          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
-          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
-          - {version: {install: 'latest',  expected: '5.0.1'}, os: {icon: '🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
-          # error message testing (outdated os version, wrong backend, unsupported runtime, ...)
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-20.04', runtime: '',        backend: 'mcode'},    option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'},    option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  },    option: {can-fail: true }}
-          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟦', name: 'Windows', image: 'windows-2022', runtime: 'mingw64', backend: 'llvm-jit'}, option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm'},     option: {can-fail: true }}
+          - {version: {install: '5.0.1',   expected: '5.0.1'}, os: {icon: '❌🪟🟨', name: 'Windows', image: 'windows-2022', runtime: 'ucrt64',  backend: 'llvm-jit'}, option: {can-fail: true }}
+          # error message testing (outdated os version, wrong backend, unsupported backend, unsupported runtime, ...)
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🐧',   name: 'Ubuntu',  image: 'ubuntu-22.04', runtime: '',        backend: 'mcode'},    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🐧',   name: 'Ubuntu',  image: 'ubuntu-24.04', runtime: '',        backend: 'xcode'},    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🍎',   name: 'macOS',   image: 'macos-13',     runtime: '',        backend: 'gcc'  },    option: {can-fail: true }}
+          - {version: {install: 'nightly', expected: '5.0.0'}, os: {icon: '❌🪟⬛', name: 'Windows', image: 'windows-2022', runtime: 'mingw32', backend: 'mcode'},    option: {can-fail: true }}
 
     continue-on-error: ${{ matrix.option.can-fail }}
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This composite action, installs GHDL in a GitHub Action's workflow job.
   * tagged release like `5.0.1`, `5.1.1`, or
   * latest release, currently `5.1.1`, or
   * `nightly` release (rolling release).
+  * `latest` release (retrieved from latest *nightly release*'s `inventory.json`).
 * Select GHDL backend:
   * mcode
   * LLVM
@@ -24,7 +25,7 @@ This composite action, installs GHDL in a GitHub Action's workflow job.
   * Ubuntu 24.04 (LTS),
   * macOS-13 (x86-64),
   * macOS-14 (aarch64)
-  * Windows Server 2022.
+  * Windows Server 2025.
 
 ## Usage
 
@@ -80,7 +81,7 @@ jobs:
 
 | Parameter           | Required | Default     | Description                                                                                                                                 |
 |---------------------|:--------:|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `version`           |    no    | `'nightly'` | A tagged GHDL version starting at `v5.1.1` or `nightly`.                                                                                    |
+| `version`           |    no    | `'nightly'` | A tagged GHDL version starting at `v5.1.1`, `latest` or `nightly`.                                                                          |
 | `backend`           |    no    | `'mcode'`   | GHDL backend: `llvm`, `llvm-jit`, `mcode`, `gcc`.                                                                                           |
 | `runtime`           |    no    | `''`        | If runner OS is Windows, a MSYS2 runtime can be selected (`mingw64`, `ucrt64`). If not set, Windows native is used (not MSYS2 environment). |
 | `install-directory` |    no    | `'install'` | Local installation directory, in case an archive asset is downloaded and extracted.                                                         |

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ This composite action, installs GHDL in a GitHub Action's workflow job.
 ## Features
 
 * Select GHDL version:
-  * tagged release like `5.0.1`, or
-  * latest release, currently `5.0.1`, or
+  * tagged release like `5.0.1`, `5.1.1`, or
+  * latest release, currently `5.1.1`, or
   * `nightly` release (rolling release).
 * Select GHDL backend:
   * mcode
@@ -80,7 +80,7 @@ jobs:
 
 | Parameter           | Required | Default     | Description                                                                                                                                 |
 |---------------------|:--------:|-------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `version`           |    no    | `'nightly'` | A tagged GHDL version starting at `v5.0.0` or `nightly`.                                                                                    |
+| `version`           |    no    | `'nightly'` | A tagged GHDL version starting at `v5.1.1` or `nightly`.                                                                                    |
 | `backend`           |    no    | `'mcode'`   | GHDL backend: `llvm`, `llvm-jit`, `mcode`, `gcc`.                                                                                           |
 | `runtime`           |    no    | `''`        | If runner OS is Windows, a MSYS2 runtime can be selected (`mingw64`, `ucrt64`). If not set, Windows native is used (not MSYS2 environment). |
 | `install-directory` |    no    | `'install'` | Local installation directory, in case an archive asset is downloaded and extracted.                                                         |

--- a/action.yml
+++ b/action.yml
@@ -152,7 +152,7 @@ runs:
         # A generic test for supported named versions or tagged versions.
         if [[ "${{ inputs.version }}" == "latest" ]]; then
           # TODO: could be read from nightly's inventory.json
-          VERSION_IN_URL="v5.0.1"
+          VERSION_IN_URL="v5.1.1"
         elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?|nightly$ ]]; then
           VERSION_IN_URL="${{ inputs.version }}"
         elif [[ "${{ inputs.version }}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?$ ]]; then

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,15 @@ runs:
 
         printf "%s" "Check if GHDL backend '${{ inputs.backend }}' is supported for this runner OS version ... "
         if jq -e ".files.ghdl.\"${osName,,}\".\"${osMajorVersion}\".\"${osArchitecture}\".\"${osRuntime}\" | has(\"${{ inputs.backend }}\")" inventory.json > /dev/null; then
-          printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          if jq -e ".files.ghdl.\"${osName,,}\".\"${osMajorVersion}\".\"${osArchitecture}\".\"${osRuntime}\".\"${{ inputs.backend }}\" | has(\"error\")" inventory.json > /dev/null; then
+            errorMessage="$(jq -r ".files.ghdl.\"${osName,,}\".\"${osMajorVersion}\".\"${osArchitecture}\".\"${osRuntime}\".\"${{ inputs.backend }}\".error" inventory.json)"
+            printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[SUPPORT DROPPED]"
+            printf "${ANSI_LIGHT_RED}  %s${ANSI_NOCOLOR}\n" "${errorMessage}"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Support for GHDL backend '${{ inputs.backend }}' for ${osName} ${osMajorVersion} was dropped. Reason: ${errorMessage}"
+            exit 1
+          else
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          fi
         else
           printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[UNSUPPORTED]"
           printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported GHDL backend '${{ inputs.backend }}' for ${osName} ${osMajorVersion}."

--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,20 @@ runs:
 
         # A generic test for supported named versions or tagged versions.
         if [[ "${{ inputs.version }}" == "latest" ]]; then
+          DOWNLOAD_URL="https://github.com/ghdl/ghdl/releases/download/nightly/inventory.json"
+          printf "::group::${ANSI_LIGHT_BLUE}%s${ANSI_NOCOLOR}\n" "Downloading nightly inventory file from '${DOWNLOAD_URL}' ..."
+          curl -L --fail "${DOWNLOAD_URL}" -o nightly.json
+          retCode=$?
+          printf "::endgroup::\n  Downloading nightly inventory "
+          if [[ $retCode -eq 0 ]]; then
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          else
+            printf "${ANSI_LIGHT_RED}%s\${ANSI_NOCOLOR}n" "[FAILED]"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Failed to download 'inventory.json' as 'nightly.json'."
+            exit 1
+          fi
+
+
           # TODO: could be read from nightly's inventory.json
           VERSION_IN_URL="v5.1.1"
         elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?|nightly$ ]]; then

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
           fi
 
           osName="Windows"
-          osMajorVersion="2022"
+          osMajorVersion="2025"
           osArchitecture="x86-64"
         else
           printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported runner OS '${{ runner.os }}'."

--- a/action.yml
+++ b/action.yml
@@ -150,7 +150,9 @@ runs:
         fi
 
         # A generic test for supported named versions or tagged versions.
-        if [[ "${{ inputs.version }}" == "latest" ]]; then
+        if [[ "${{ inputs.version }}" == "nightly" ]]; then
+          VERSION_IN_URL="nightly"
+        elif [[ "${{ inputs.version }}" == "latest" ]]; then
           DOWNLOAD_URL="https://github.com/ghdl/ghdl/releases/download/nightly/inventory.json"
           printf "::group::${ANSI_LIGHT_BLUE}%s${ANSI_NOCOLOR}\n" "Downloading nightly inventory file from '${DOWNLOAD_URL}' ..."
           curl -L --fail "${DOWNLOAD_URL}" -o nightly.json
@@ -164,10 +166,21 @@ runs:
             exit 1
           fi
 
+          printf "%s" "Check if 'latest release' is supported (JSON structure version 1.1) ... "
+          if jq -e ".version != \"1.1\"" nightly.json > /dev/null; then
+            printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[OUTDATED]"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported feature 'install latest version' due to outdated 'inventory.json' format."
+            exit 1
+          elif jq -e ".meta | has(\"latest\")" nightly.json > /dev/null; then
+            printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+          else
+            printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[UNSUPPORTED]"
+            printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported feature 'install latest version' due to missing information in 'inventory.json' downloaded from latest 'nightly' release."
+            exit 1
+          fi
 
-          # TODO: could be read from nightly's inventory.json
-          VERSION_IN_URL="v5.1.1"
-        elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?|nightly$ ]]; then
+          VERSION_IN_URL="$(jq -r '.meta.latest.version' nightly.json)"
+        elif [[ "${{ inputs.version }}" =~ ^v[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?$ ]]; then
           VERSION_IN_URL="${{ inputs.version }}"
         elif [[ "${{ inputs.version }}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-rc[0-9]+)?$ ]]; then
           VERSION_IN_URL="v${{ inputs.version }}"

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ runs:
           fi
 
           printf "%s" "Check if 'latest release' is supported (JSON structure version 1.1) ... "
-          if jq -e ".version != \"1.1\"" nightly.json > /dev/null; then
+          if jq -e ".version | tonumber | . < 1.1" nightly.json > /dev/null; then
             printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[OUTDATED]"
             printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported feature 'install latest version' due to outdated 'inventory.json' format."
             exit 1
@@ -209,6 +209,15 @@ runs:
         else
           printf "${ANSI_LIGHT_RED}%s\${ANSI_NOCOLOR}n" "[FAILED]"
           printf "::error title=%s::%s\n" "setup-ghdl" "Failed to download 'inventory.json'."
+          exit 1
+        fi
+
+        printf "%s" "Check JSON structure version ... "
+        if jq -e ".version | tonumber | . >= 1.0 and . < 2.0" inventory.json > /dev/null; then
+          printf "${ANSI_LIGHT_GREEN}%s${ANSI_NOCOLOR}\n" "[OK]"
+        else
+          printf "${ANSI_LIGHT_RED}%s${ANSI_NOCOLOR}\n" "[MISMATCH]"
+          printf "::error title=%s::%s\n" "setup-ghdl" "Unsupported version '$(jq ".version" inventory.json)' of 'inventory.json' format."
           exit 1
         fi
 

--- a/example/HelloWorld.vhdl
+++ b/example/HelloWorld.vhdl
@@ -1,0 +1,12 @@
+entity HelloWorld is
+end entity;
+
+architecture test of HelloWorld is
+begin
+  process
+  begin
+	wait for 10 ns;
+	report "Hello World" severity note;
+	std.env.stop;
+  end process;
+end architecture;


### PR DESCRIPTION
# New Features

* Support GHDL v5.1.1.
* Shop error message from `inventory.json` if a previously supported version was revoked.
* Added symbolic version `latest`, which gets the *latest* released version from latest `nightly` build via `inventory.json`.

# Changes

* Setup a CODEOWNERS file.

# Documentation

* Documented symbolic version `latest`.

# Unit Tests

* Reactivated tests for `latest` and `nightly`.
* Added HelloWorld example.  
  Closes #16.

----------
# Related Issues and Pull-Requests

* #19
